### PR TITLE
Add 'Auto PWM default ON' settings

### DIFF
--- a/indi_astrolink4usb.cpp
+++ b/indi_astrolink4usb.cpp
@@ -20,7 +20,7 @@
 #include "indicom.h"
 
 #define VERSION_MAJOR 0
-#define VERSION_MINOR 3
+#define VERSION_MINOR 4
 
 #define ASTROLINK4_LEN 200
 #define ASTROLINK4_TIMEOUT 3
@@ -210,8 +210,19 @@ bool IndiAstrolink4USB::initProperties()
     IUFillNumberVector(&PWMNP, PWMN, 2, getDeviceName(), "PWM", "PWM", POWER_TAB, IP_RW, 60, IPS_IDLE);
 
     // Auto pwm
-    IUFillSwitch(&AutoPWMS[0], "PWMA_A", "A", ISS_OFF);
-    IUFillSwitch(&AutoPWMS[1], "PWMA_B", "B", ISS_OFF);
+    IUFillSwitch(&AutoPWMDefaultOnS[0], "PWMA_A_DEF_ON", "A", ISS_OFF);
+    IUFillSwitch(&AutoPWMDefaultOnS[1], "PWMA_B_DEF_ON", "B", ISS_OFF);
+    IUFillSwitchVector(&AutoPWMDefaultOnSP, AutoPWMDefaultOnS, 2, getDeviceName(), "AUTO_PWM_DEF_ON", "Auto PWM default ON", SETTINGS_TAB,
+                       IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
+
+    ISState pwmAutoA = ISS_OFF;
+    IUGetConfigSwitch(getDeviceName(), AutoPWMDefaultOnSP.name, AutoPWMDefaultOnS[0].name, &pwmAutoA);
+
+    ISState pwmAutoB = ISS_OFF;
+    IUGetConfigSwitch(getDeviceName(), AutoPWMDefaultOnSP.name, AutoPWMDefaultOnS[1].name, &pwmAutoB);
+
+    IUFillSwitch(&AutoPWMS[0], "PWMA_A", "A", pwmAutoA);
+    IUFillSwitch(&AutoPWMS[1], "PWMA_B", "B", pwmAutoB);
     IUFillSwitchVector(&AutoPWMSP, AutoPWMS, 2, getDeviceName(), "AUTO_PWM", "Auto PWM", POWER_TAB, IP_RW, ISR_NOFMANY, 60, IPS_OK);
 
     IUFillNumber(&PowerDataN[POW_VIN], "VIN", "Input voltage [V]", "%.1f", 0, 15, 10, 0);
@@ -273,6 +284,7 @@ bool IndiAstrolink4USB::updateProperties()
         defineProperty(&CompensationValueNP);
         defineProperty(&CompensateNowSP);
         defineProperty(&PowerDefaultOnSP);
+        defineProperty(&AutoPWMDefaultOnSP);
         defineProperty(&OtherSettingsNP);
         defineProperty(&PowerControlsLabelsTP);
         defineProperty(&BuzzerSP);
@@ -292,6 +304,7 @@ bool IndiAstrolink4USB::updateProperties()
         deleteProperty(CompensateNowSP.name);
         deleteProperty(CompensationValueNP.name);
         deleteProperty(PowerDefaultOnSP.name);
+        deleteProperty(AutoPWMDefaultOnSP.name);
         deleteProperty(OtherSettingsNP.name);
         deleteProperty(BuzzerSP.name);
         deleteProperty(FocuserCompModeSP.name);
@@ -493,6 +506,16 @@ bool IndiAstrolink4USB::ISNewSwitch(const char *dev, const char *name, ISState *
             return true;
         }
 
+        // Auto PWM default on
+        if (!strcmp(name, AutoPWMDefaultOnSP.name))
+        {
+            IUUpdateSwitch(&AutoPWMDefaultOnSP, states, names, n);
+            AutoPWMDefaultOnSP.s = IPS_OK;
+            saveConfig();
+            IDSetSwitch(&AutoPWMDefaultOnSP, nullptr);
+            return true;
+        }
+
         // Buzzer
         if (!strcmp(name, BuzzerSP.name))
         {
@@ -610,6 +633,7 @@ bool IndiAstrolink4USB::saveConfigItems(FILE *fp)
     FI::saveConfigItems(fp);
 
     IUSaveConfigText(fp, &PowerControlsLabelsTP);
+    IUSaveConfigSwitch(fp, &AutoPWMDefaultOnSP);
     return true;
 }
 

--- a/indi_astrolink4usb.h
+++ b/indi_astrolink4usb.h
@@ -235,6 +235,9 @@ private:
     ISwitch PowerDefaultOnS[3];
     ISwitchVectorProperty PowerDefaultOnSP;
     
+    ISwitch AutoPWMDefaultOnS[2];
+    ISwitchVectorProperty AutoPWMDefaultOnSP;
+
     INumber OtherSettingsN[4];
     INumberVectorProperty OtherSettingsNP;
     enum


### PR DESCRIPTION
Hi,

This PR add a new switch vector `Auto PWM default ON` to the `Settings` tab. When checked, the corresponding `Auto PWM` are enabled on driver start.

I for one systematically forget to start the dew heaters on ekos boot. The `Power default ON` behavior cannot be replicated exactly because it is save in the device, whereas dew heaters configuration is saved in the INDI xml file. Dew heaters therefore start on driver start, not when the device boots. This is really convenient, and close enough to be a worthwhile addition to the driver IMO  !

![image](https://user-images.githubusercontent.com/5184737/152888634-9dda9970-1271-4626-83ab-f60f9357fa2a.png)
![image](https://user-images.githubusercontent.com/5184737/152888682-7fbad3e1-6165-421a-8717-3e97e887b29f.png)

If you deem this addition useful, i'll open a PR over the indi-3rdparty repository for the regular astrolink4 driver as well 🙂 