### PR TITLE
Fix driver version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,12 @@
-cmake_minimum_required(VERSION 2.4.7)
+cmake_minimum_required(VERSION 3.2)
 PROJECT(indi-astrolink4usb CXX C)
 
 set (ASTROLINK4_VERSION_MAJOR 0)
 set (ASTROLINK4_VERSION_MINOR 4)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-set(BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin")
-set(CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS}")
 
+SET(CMAKE_CXX_STANDARD 11)
 
 find_package(INDI REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.4.7)
 PROJECT(indi-astrolink4usb CXX C)
 
-set (VERSION_MAJOR 0)
-set (VERSION_MINOR 1)
+set (ASTROLINK4_VERSION_MAJOR 0)
+set (ASTROLINK4_VERSION_MINOR 4)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 set(BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin")
@@ -15,6 +15,9 @@ include_directories( ${CMAKE_CURRENT_BINARY_DIR})
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories( ${INDI_INCLUDE_DIR})
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_astrolink4usb.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_astrolink4usb.xml )
+
 ################ AstroLink4 ################
 
 set(indi_astrolink4usb_SRCS
@@ -23,6 +26,7 @@ set(indi_astrolink4usb_SRCS
 
 add_executable(indi_astrolink4usb ${indi_astrolink4usb_SRCS})
 target_link_libraries(indi_astrolink4usb indidriver)
+
 install(TARGETS indi_astrolink4usb RUNTIME DESTINATION bin )
-install(FILES indi_astrolink4usb.xml DESTINATION ${INDI_DATA_DIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_astrolink4usb.xml DESTINATION ${INDI_DATA_DIR})
 

--- a/astrolink4usb.xml
+++ b/astrolink4usb.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<driversList>
-<devGroup group="Auxiliary">
-        <device label="AstroLink 4 USB">
-                <driver name="AstroLink4 USB">astrolink4usb</driver>
-                <version>0.1</version>
-        </device>
-</devGroup>
-</driversList>

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,0 +1,10 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+/* Define INDI Data Dir */
+#cmakedefine INDI_DATA_DIR "@INDI_DATA_DIR@"
+/* Define Driver version */
+#define ASTROLINK4_VERSION_MAJOR @ASTROLINK4_VERSION_MAJOR@
+#define ASTROLINK4_VERSION_MINOR @ASTROLINK4_VERSION_MINOR@
+
+#endif // CONFIG_H

--- a/indi_astrolink4usb.cpp
+++ b/indi_astrolink4usb.cpp
@@ -16,11 +16,9 @@
  Boston, MA 02110-1301, USA.
 *******************************************************************************/
 #include "indi_astrolink4usb.h"
+#include "config.h"
 
 #include "indicom.h"
-
-#define VERSION_MAJOR 0
-#define VERSION_MINOR 4
 
 #define ASTROLINK4_LEN 200
 #define ASTROLINK4_TIMEOUT 3
@@ -35,7 +33,7 @@ std::unique_ptr<IndiAstrolink4USB> indiAstrolink4USB(new IndiAstrolink4USB());
 //////////////////////////////////////////////////////////////////////
 IndiAstrolink4USB::IndiAstrolink4USB() : FI(this), WI(this)
 {
-    setVersion(VERSION_MAJOR, VERSION_MINOR);
+    setVersion(ASTROLINK4_VERSION_MAJOR, ASTROLINK4_VERSION_MINOR);
 }
 
 const char *IndiAstrolink4USB::getDefaultName()

--- a/indi_astrolink4usb.xml.cmake
+++ b/indi_astrolink4usb.xml.cmake
@@ -3,7 +3,7 @@
 <devGroup group="Auxiliary">
         <device label="AstroLink 4 USB">
                 <driver name="AstroLink4 USB">indi_astrolink4usb</driver>
-                <version>0.1</version>
+                <version>@ASTROLINK4_VERSION_MAJOR@.@ASTROLINK4_VERSION_MINOR@</version>
         </device>
 </devGroup>
 </driversList>


### PR DESCRIPTION
Hi,

This PR fixes the driver version declaration, as pointed out [here](https://github.com/indilib/indi-3rdparty/pull/549#issuecomment-1048471727) for the astrolink4 driver.

Apparently, version should only be driven by the CMakeLists.txt file, which based on `.cmake` template files outputs a `config.h` used by `indi_astrolink4usb.cpp` and a `indi_astrolink4usb.xml` where both versions numbers are replaced.

This avoid mistakes in version declaration. For instance in my previous PR https://github.com/astrojolo/astrolink4usb/pull/4 I forgot to increment the version number inside the xml. Moreover, versions constants weren't used at all as `indi_astrolink4usb.xml` was hardcoded and copied to the install directory.

I honestly don't know what the version inside the xml is used for, as the version reported in the driver panel is the one from the call to `setVersion`. At least now, there is only one entry to change, and it matches what is usually done within indi drivers.

Finally, `astrolink4usb.xml` is not needed and was removed from the repository.

I also updated the `cmake_minimum_required` to get rid of a deprecation warning, and aligned the CMakeLists.txt with the one inside indi-3rdparty repo 🙂 

> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
>  Compatibility with CMake < 2.8.12 will be removed from a future version of
>  CMake.
>
> Update the VERSION argument <min> value or use a ...<max> suffix to tell
> CMake that the project does not need compatibility with older versions.